### PR TITLE
Switching to setuptools from distutils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: python
 python:
- - "2.6"
  - "2.7"
- - "3.2"
- - "3.3"
  - "3.4"
  - "pypy"
 before_install:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 import sys
 import unittest
-from distutils.core import setup, Command
+from setuptools import setup, Command
 
 
 class Test(Command):


### PR DESCRIPTION
This just switches to importing these from setuptools which supports --single-version-externally-managed.  I need this for the OpenBSD port I'm creating and it should work the same for use cases outside of packaging.